### PR TITLE
Fix credentials initialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ allprojects {
       resolutionStrategy {
         force 'org.antlr:antlr-runtime:3.5.2'
         force 'com.amazonaws:aws-java-sdk-core:1.10.5.1'
+        force 'com.fasterxml:classmate:1.2.0'
         eachDependency {
           if (it.requested.group == 'asm' || it.requested.group == 'org.ow2.asm') {
             it.useTarget group: 'org.ow2.asm', name: 'asm-all', version: '5.0.3'

--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/polling/PollingDirector.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/polling/PollingDirector.scala
@@ -3,8 +3,7 @@ package com.netflix.spinnaker.tide.actor.polling
 
 import akka.actor.{Actor, ActorRef, Props}
 import akka.contrib.pattern.ClusterSharding
-import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig
-import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig.Account
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials
 import com.netflix.spinnaker.tide.actor.SingletonActorObject
 import com.netflix.spinnaker.tide.actor.classiclink.ClassicLinkInstancesActor
 import com.netflix.spinnaker.tide.actor.classiclink.ClassicLinkInstancesActor.ClassicLinkSecurityGroupNames
@@ -47,8 +46,7 @@ class PollingDirector extends Actor {
       getShardCluster(PipelinePollingActor.typeName) ! PipelinePoll()
       val pollers: Seq[PollingActorObject] =Seq(VpcPollingActor, ClassicLinkInstanceIdPollingActor,
         SecurityGroupPollingActor, LoadBalancerPollingActor, ServerGroupPollingActor)
-      val accounts: Set[Account] = pollInit.credentialsConfig.getAccounts.asScala.toSet
-      for (account <- accounts) {
+      for (account <- pollInit.accounts) {
         val regions = account.getRegions.asScala
         for (region <- regions) {
           val location = AwsLocation(account.getName, region.getName)
@@ -70,7 +68,7 @@ sealed trait PollingDirectorProtocol extends Serializable
 object PollingDirector extends SingletonActorObject {
   val props = Props[PollingDirector]
 
-  case class PollInit(credentialsConfig: CredentialsConfig, classicLinkSecurityGroupNames: Seq[String]) extends PollingDirectorProtocol
+  case class PollInit(accounts: Set[NetflixAmazonCredentials], classicLinkSecurityGroupNames: Seq[String]) extends PollingDirectorProtocol
   case class Poll() extends PollingDirectorProtocol
 
 }

--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/config/AkkaClusterConfiguration.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/config/AkkaClusterConfiguration.scala
@@ -20,7 +20,7 @@ import javax.annotation.PostConstruct
 
 import akka.actor.{Props, ActorSystem}
 import akka.contrib.pattern.ClusterSharding
-import com.netflix.spinnaker.clouddriver.aws.security.config.CredentialsConfig
+import com.netflix.spinnaker.clouddriver.security.AccountCredentialsRepository
 import com.netflix.spinnaker.config.OkHttpClientConfiguration
 import com.netflix.spinnaker.tide.actor.aws._
 import com.netflix.spinnaker.tide.actor.classiclink.{AttachClassicLinkActor, ClassicLinkInstancesActor}
@@ -46,7 +46,7 @@ class AkkaClusterConfiguration {
 
   @Autowired var system: ActorSystem = _
 
-  @Autowired var credentialsConfig: CredentialsConfig = _
+  @Autowired var accountCredentialsRepository: AccountCredentialsRepository = _
 
   @Autowired var okHttpClientConfiguration: OkHttpClientConfiguration = _
 
@@ -95,7 +95,7 @@ class AkkaClusterConfiguration {
     clusterSharding.shardRegion(CloudDriverActor.typeName) ! CloudDriverInit(cloudDriverApiUrl)
     clusterSharding.shardRegion(Front50Actor.typeName) ! Front50Init(front50ApiUrl)
     val classicLinkSecurityGroupNames: Seq[String] = classicLinkSettings.getSecurityGroups.asScala
-    val props = Props(classOf[ContinuousInitActor], clusterSharding, credentialsConfig, classicLinkSecurityGroupNames)
+    val props = Props(classOf[ContinuousInitActor], clusterSharding, accountCredentialsRepository, classicLinkSecurityGroupNames)
     system.actorOf(props, "ContinuousInit")
   }
 

--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/config/AwsConfig.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/config/AwsConfig.scala
@@ -2,27 +2,29 @@ package com.netflix.spinnaker.tide.config
 
 import javax.annotation.PostConstruct
 
+import com.amazonaws.retry.RetryPolicy
+import com.netflix.awsobjectmapper.AmazonObjectMapper
 import com.netflix.spinnaker.cats.provider.ProviderSynchronizerTypeWrapper
-import com.netflix.spinnaker.clouddriver.aws.security.{AmazonClientProvider, NetflixAmazonCredentials}
-import com.netflix.spinnaker.clouddriver.security.{AccountCredentialsRepository, ProviderUtils}
+import com.netflix.spinnaker.clouddriver.aws.bastion.BastionConfig
+import com.netflix.spinnaker.clouddriver.aws.security.{AmazonCredentialsInitializer, AmazonClientProvider, NetflixAmazonCredentials}
+import com.netflix.spinnaker.clouddriver.security.{MapBackedAccountCredentialsRepository, AccountCredentialsRepository, ProviderUtils}
 import com.netflix.spinnaker.tide.config.AwsConfig.AwsProviderSynchronizer
 import com.netflix.spinnaker.tide.model.AwsServiceProviderFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.context.annotation.{DependsOn, Bean, ComponentScan, Configuration}
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation._
 import collection.JavaConverters._
 import scala.collection.mutable
 
 @Configuration
 @ConditionalOnProperty(Array("aws.enabled"))
-@ComponentScan(Array("com.netflix.spinnaker.clouddriver.aws", "com.netflix.spinnaker.clouddriver.core"))
+@EnableConfigurationProperties
+@Import(Array( classOf[BastionConfig], classOf[AmazonCredentialsInitializer] ))
 class AwsConfig {
-
-  @Autowired var amazonClientProvider: AmazonClientProvider = _
 
   @Bean
   @DependsOn(Array("netflixAmazonCredentials"))
-  def awsServiceProviderFactory(accountCredentialsRepository: AccountCredentialsRepository): AwsServiceProviderFactory = {
+  def awsServiceProviderFactory(accountCredentialsRepository: AccountCredentialsRepository, amazonClientProvider: AmazonClientProvider): AwsServiceProviderFactory = {
     def allAccounts = ProviderUtils.buildThreadSafeSetOfAccounts(accountCredentialsRepository,
       classOf[NetflixAmazonCredentials]).asScala
     def allNetflixAccounts = allAccounts.asInstanceOf[mutable.Set[NetflixAmazonCredentials]].toSet
@@ -39,6 +41,15 @@ class AwsConfig {
     override def getSynchronizerType: Class[AwsProviderSynchronizer] = classOf[AwsProviderSynchronizer]
   }
 
+  @Bean
+  def amazonClientProvider(): AmazonClientProvider = {
+    new AmazonClientProvider.Builder().objectMapper(new AmazonObjectMapper()).build()
+  }
+
+  @Bean
+  def accountCredentialsRepository(): AccountCredentialsRepository = {
+    new MapBackedAccountCredentialsRepository()
+  }
 }
 
 object AwsConfig {

--- a/tide-core/tide-core.gradle
+++ b/tide-core/tide-core.gradle
@@ -5,15 +5,15 @@ configurations {
 dependencies {
   spinnaker.group("retrofitDefault")
 
-  compile 'com.netflix.spinnaker.clouddriver:clouddriver-core:1.30.0'
-  compile 'com.netflix.spinnaker.clouddriver:clouddriver-aws:1.30.0'
-  compile 'com.netflix.spinnaker.clouddriver:clouddriver-security:1.30.0'
+  compile 'com.netflix.spinnaker.clouddriver:clouddriver-core:1.43.0'
+  compile 'com.netflix.spinnaker.clouddriver:clouddriver-aws:1.43.0'
+  compile 'com.netflix.spinnaker.clouddriver:clouddriver-security:1.43.0'
   spinnaker.group('amazon')
 
   compile spinnaker.dependency("korkWeb")
   compile spinnaker.dependency("springContext")
   compile spinnaker.dependency("jacksonJsr310")
-  compile 'org.springframework.boot:spring-boot:1.2.1.RELEASE'
+  compile 'org.springframework.boot:spring-boot:1.2.5.RELEASE'
 
   testCompile 'junit:junit:4.12'
 }


### PR DESCRIPTION
PollInit message contained the wrong object for credentials configuration
Updates to newer clouddriver to fix error when there is no default VPC and we are trying to resolve the accountId. 
Stop component-scanning clouddriver so there is some sliver of hope that using the credentials init as a library is a viable strategy