### PR TITLE
changing front50 pipeline save endpoint

### DIFF
--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/copy/PipelineDeepCopyActor.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/copy/PipelineDeepCopyActor.scala
@@ -21,12 +21,12 @@ import akka.contrib.pattern.ClusterSharding
 import akka.persistence.{RecoveryFailure, PersistentActor, RecoveryCompleted}
 import akka.util.Timeout
 import com.netflix.spinnaker.tide.actor.aws.PipelineActor.{PipelineDetails, GetPipeline}
-import com.netflix.spinnaker.tide.actor.service.Front50Actor.AddPipelines
+import com.netflix.spinnaker.tide.actor.service.Front50Actor.SavePipeline
 import com.netflix.spinnaker.tide.actor.{ClusteredActorObject, TaskActorObject}
 import com.netflix.spinnaker.tide.actor.aws.PipelineActor
 import com.netflix.spinnaker.tide.actor.copy.DependencyCopyActor.{DependencyCopyTaskResult, DependencyCopyTask}
 import com.netflix.spinnaker.tide.actor.copy.PipelineDeepCopyActor.{CreatePipeline, StartPipelineCloning, PipelineDeepCopyTaskResult, PipelineDeepCopyTask}
-import com.netflix.spinnaker.tide.actor.polling.{SecurityGroupPollingContract, SecurityGroupPollingContractActor, SecurityGroupPollingActor}
+import com.netflix.spinnaker.tide.actor.polling.{SecurityGroupPollingContract, SecurityGroupPollingContractActor}
 import com.netflix.spinnaker.tide.actor.polling.SecurityGroupPollingActor.GetSecurityGroupIdToNameMappings
 import com.netflix.spinnaker.tide.actor.service.Front50Actor
 import com.netflix.spinnaker.tide.actor.task.TaskActor._
@@ -145,7 +145,7 @@ class PipelineDeepCopyActor extends PersistentActor with ActorLogging {
       sendTaskEvent(Mutation(taskId, Create(), CreatePipeline(newPipeline)))
       if (!task.dryRun) {
         sendTaskEvent(Log(taskId, s"Cloning pipeline '${pipelineState.name}'"))
-        clusterSharding.shardRegion(Front50Actor.typeName) ! AddPipelines(List(newPipeline))
+        clusterSharding.shardRegion(Front50Actor.typeName) ! SavePipeline(newPipeline)
       }
       self ! TaskSuccess(taskId, task, PipelineDeepCopyTaskResult("")) // TODO: get new pipeline ID
 

--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/service/Front50Actor.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/service/Front50Actor.scala
@@ -18,15 +18,15 @@ package com.netflix.spinnaker.tide.actor.service
 
 import akka.actor.Props
 import com.netflix.spinnaker.tide.actor.SingletonActorObject
-import com.netflix.spinnaker.tide.actor.service.Front50Actor.{FoundPipeline, GetPipelines, AddPipelines}
+import com.netflix.spinnaker.tide.actor.service.Front50Actor.{SavePipeline, FoundPipeline, GetPipelines}
 import com.netflix.spinnaker.tide.model.Front50Service
 import com.netflix.spinnaker.tide.model.Front50Service.{Pipeline, PipelineState}
 
 class Front50Actor extends RetrofitServiceActor[Front50Service] {
 
   override def operational: Receive = {
-    case msg: AddPipelines =>
-      service.addPipelines(msg.pipelines)
+    case msg: SavePipeline =>
+      service.savePipeline(msg.pipeline)
     case msg: GetPipelines =>
       service.getAllPipelines.foreach{ pipeline =>
         sender ! FoundPipeline(pipeline)
@@ -47,6 +47,6 @@ object Front50Actor extends SingletonActorObject {
 
   case class GetPipelines() extends Front50Protocol
   case class FoundPipeline(pipeline: Pipeline) extends Front50Protocol
-  case class AddPipelines(pipelines: Seq[PipelineState]) extends Front50Protocol
+  case class SavePipeline(pipeline: PipelineState) extends Front50Protocol
 
 }

--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/model/Front50Service.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/model/Front50Service.scala
@@ -26,7 +26,7 @@ trait Front50Service {
   def getAllPipelines: Seq[Pipeline]
 
   @Headers (Array ("Accept: application/json") )
-  @POST ("/pipelines/batchUpdate") def addPipelines (@Body pipelines: Seq[PipelineState]): String
+  @POST ("/pipelines") def savePipeline(@Body pipeline: PipelineState): String
 }
 
 object Front50Service {


### PR DESCRIPTION
BatchUpdate is throwing NPEs now, and I don't actually need it anyway since I only save one at a time.