### PR TITLE
send correct vpcId when creating ingress security groups

### DIFF
--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/service/CloudDriverActor.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/service/CloudDriverActor.scala
@@ -100,7 +100,7 @@ object ConstructCloudDriverOperations {
         val vpcId: Option[String] = userIdGroupPair.vpcName match {
           case Some(vpcName) =>
             val vpcsForLocationOption = vpcs.get(awsReference.location.copy(account = userIdGroupPair.account.name.get))
-            vpcsForLocationOption.flatMap(_.find(_.name == vpcName).flatMap(_.name))
+            vpcsForLocationOption.flatMap(_.find(_.name.contains(vpcName)).map(_.vpcId))
           case None => None
         }
         securityGroupIngress += SecurityGroupIngress.from(userIdGroupPair, ipPermission, vpcId)


### PR DESCRIPTION
Tide currently does not send any vpcId when adding the ingress side of migrated security groups. This is usually fine - Clouddriver adds the VPC of the parent security group if it's missing, and everything is fine. Except if the ingress group is in a different account - in that case, Clouddriver fails to find that group and the migration fails.

Thanks to @robfletcher for helping figure this out.