### PR TITLE
allow user to specify a target subnet when performing a migration

### DIFF
--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/copy/ServerGroupDeepCopyActor.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/copy/ServerGroupDeepCopyActor.scala
@@ -123,7 +123,7 @@ class ServerGroupDeepCopyActor() extends PersistentActor with ActorLogging {
       val cloudDriver = clusterSharding.shardRegion(CloudDriverActor.typeName)
       if (cloneServerGroupTaskReference.isEmpty) {
         val sourceVpcName = serverGroupState.autoScalingGroup.vpcName
-        val newAutoScalingGroup = serverGroupState.autoScalingGroup.forVpc(sourceVpcName, task.target.vpcName).withCapacity(0)
+        val newAutoScalingGroup = serverGroupState.autoScalingGroup.forVpc(sourceVpcName, task.target.vpcName, task.targetSubnetType).withCapacity(0)
         val newLaunchConfiguration = serverGroupState.launchConfiguration.dropSecurityGroupNameLegacySuffixes.copy(
           securityGroups = serverGroupState.launchConfiguration.securityGroups + appName)
         val cloneServerGroup = CloneServerGroup(newAutoScalingGroup, newLaunchConfiguration, startDisabled = true)
@@ -202,6 +202,7 @@ object ServerGroupDeepCopyActor extends TaskActorObject {
   case class ServerGroupDeepCopyTask(source: AwsReference[AutoScalingGroupIdentity],
                                      target: VpcLocation,
                                      allowIngressFromClassic: Boolean = true,
+                                     targetSubnetType: Option[String],
                                      dryRun: Boolean = false)
     extends TaskDescription with ServerGroupDeepCopyProtocol {
     val taskType: String = "ServerGroupDeepCopyTask"

--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/model/AwsApi.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/model/AwsApi.scala
@@ -258,11 +258,11 @@ object AwsApi {
                                    maxSize: Int, minSize: Int, suspendedProcesses: Set[String],
                                    terminationPolicies: Set[String],
                                    subnetType: Option[String], vpcName: Option[String]) extends AwsProtocol {
-    def forVpc(sourceVpcName: Option[String], targetVpcName: Option[String]): AutoScalingGroupState = {
+    def forVpc(sourceVpcName: Option[String], targetVpcName: Option[String], targetSubnetType: Option[String]): AutoScalingGroupState = {
       val newLoadBalancerNames = loadBalancerNames.map(LoadBalancerIdentity(_).
         forVpc(sourceVpcName, targetVpcName).loadBalancerName)
       this.copy(loadBalancerNames = newLoadBalancerNames, vpcName = targetVpcName,
-        subnetType = constructTargetSubnetType(subnetType.getOrElse("internal"), targetVpcName),
+        subnetType = constructTargetSubnetType(targetSubnetType.getOrElse(subnetType.getOrElse("internal")), targetVpcName),
         VPCZoneIdentifier = ""
       )
     }

--- a/tide-web/src/main/scala/com/netflix/spinnaker/tide/controllers/AwsResourceController.scala
+++ b/tide-web/src/main/scala/com/netflix/spinnaker/tide/controllers/AwsResourceController.scala
@@ -166,12 +166,13 @@ class AwsResourceController @Autowired()(private val clusterSharding: ClusterSha
     notes = "The pipeline and all of it's dependencies will be copied if they do not exist (security groups, load balancers used in deploy stages). Returns the task id.")
   @RequestMapping(value = Array("/pipeline/{id}/deepCopy"), method = Array(POST))
   def deepCopyPipeline(@PathVariable("id") id: String,
-                          @RequestParam(value = "allowIngressFromClassic", defaultValue = "true") allowIngressFromClassic: Boolean,
-                          @RequestParam(value = "dryRun", defaultValue = "false") dryRun: Boolean,
-                          @RequestBody pipelineVpcMigrateDefinition: PipelineVpcMigrateDefinition) = {
+                       @RequestParam(value = "allowIngressFromClassic", defaultValue = "true") allowIngressFromClassic: Boolean,
+                       @RequestParam(value = "subnetType", required = false) subnetType: String,
+                       @RequestParam(value = "dryRun", defaultValue = "false") dryRun: Boolean,
+                       @RequestBody pipelineVpcMigrateDefinition: PipelineVpcMigrateDefinition) = {
     val taskDescription = PipelineDeepCopyTask(id, pipelineVpcMigrateDefinition.sourceVpcName,
       pipelineVpcMigrateDefinition.targetVpcName,
-      allowIngressFromClassic = allowIngressFromClassic, dryRun = dryRun)
+      allowIngressFromClassic = allowIngressFromClassic, dryRun = dryRun, targetSubnetType = Option(subnetType))
     val future = (taskDirector ? taskDescription).mapTo[ExecuteTask]
     val task = Await.result(future, timeout.duration)
     task.taskId
@@ -184,11 +185,12 @@ class AwsResourceController @Autowired()(private val clusterSharding: ClusterSha
                           @PathVariable("region") region: String,
                           @PathVariable("asgName") asgName: String,
                           @RequestParam(value = "allowIngressFromClassic", defaultValue = "true") allowIngressFromClassic: Boolean,
+                          @RequestParam(value = "subnetType", required = false) targetSubnetType: String,
                           @RequestParam(value = "dryRun", defaultValue = "false") dryRun: Boolean,
                           @RequestBody target: VpcDefinition) = {
     val reference = AwsReference(AwsLocation(account, region), AutoScalingGroupIdentity(asgName))
     val taskDescription = ServerGroupDeepCopyTask(reference, target.toVpcLocation,
-      allowIngressFromClassic = allowIngressFromClassic, dryRun = dryRun)
+      allowIngressFromClassic = allowIngressFromClassic, dryRun = dryRun, targetSubnetType = Option(targetSubnetType))
     val future = (taskDirector ? taskDescription).mapTo[ExecuteTask]
     val task = Await.result(future, timeout.duration)
     task.taskId


### PR DESCRIPTION
Still need to do some Orca and Deck work to propagate these values, but this will let users select "external" as their subnet when performing classic -> VPC migrations