### PR TITLE
assign ELB security group rules based on ELB ports

### DIFF
--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/copy/PipelineDeepCopyActor.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/copy/PipelineDeepCopyActor.scala
@@ -206,7 +206,7 @@ case class ClusterVpcMigrator(sourceVpcName: Option[String], targetVpcName: Stri
         .forVpc(sourceVpcName, Option(targetVpcName)).loadBalancerName)
       val newSecurityGroups = securityGroupIdMappingByLocation.get(location) match {
         case Some(securityGroupIdsSourceToTarget) =>
-          val targetIds = cluster.getSecurityGroupIds.map(securityGroupIdsSourceToTarget.getOrElse(_, "nonexistant"))
+          val targetIds = cluster.getSecurityGroupIds.map(securityGroupIdsSourceToTarget.getOrElse(_, "nonexistent"))
           securityGroupIdsSourceToTarget.get(cluster.getApplication) match {
             case None => targetIds
             case Some(id) => targetIds + id

--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/transform/SecurityGroupConventions.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/transform/SecurityGroupConventions.scala
@@ -36,31 +36,12 @@ case class SecurityGroupConventions(appName: String, accountName: String, vpcNam
     ))
   }
 
-  private def constructElbIngress: Set[IpPermission] = {
-    Set(
-      IpPermission(
-        fromPort = Some(80),
-        toPort = Some(80),
-        ipProtocol = "tcp",
-        ipRanges = Set("0.0.0.0/0"),
-        userIdGroupPairs = Set()
-      ),
-      IpPermission(
-        fromPort = Some(443),
-        toPort = Some(443),
-        ipProtocol = "tcp",
-        ipRanges = Set("0.0.0.0/0"),
-        userIdGroupPairs = Set()
-      )
-    )
-  }
-
   def appendBoilerplateIngress(groupName: String, allowIngressFromClassic: Boolean): Set[IpPermission] = {
     groupName match {
       case name if name == appName =>
         addClassicLinkPermission(constructAppIngress, allowIngressFromClassic)
       case name if name == SecurityGroupConventions.appSecurityGroupForElbName(appName) =>
-        addClassicLinkPermission(constructElbIngress, allowIngressFromClassic)
+        addClassicLinkPermission(Set(), allowIngressFromClassic)
       case _ =>
         Set()
     }


### PR DESCRIPTION
* moves the ELB ingress rule port assignment into the DependencyCopyActor, which will have access to the ports
* only creates the ELB ingress security group if a load balancer is detected
* adds an ingress rule for each external port on the load balancer