### PR TITLE
downgrade jackson-scala to 2.6.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ allprojects {
     compile "com.typesafe.akka:akka-persistence-experimental_$versions.scala:$versions.akka"
     compile "com.typesafe.akka:akka-cluster_$versions.scala:$versions.akka"
     compile "com.typesafe.akka:akka-contrib_$versions.scala:$versions.akka"
-    compile "com.fasterxml.jackson.module:jackson-module-scala_$versions.scala:2.7.2"
+    compile "com.fasterxml.jackson.module:jackson-module-scala_$versions.scala:2.6.6"
     compile "com.squareup.okhttp:okhttp:2.4.0"
     compile 'com.netflix.frigga:frigga:0.13'
     compile "com.github.romix.akka:akka-kryo-serialization_$versions.scala:0.3.3"


### PR DESCRIPTION
2.7.x is causing the `taskComplete` object to be empty. Hopefully 2.6.6 still works with platform/spinnaker bits...