### PR TITLE
enable cross-account migrations

### DIFF
--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/copy/DependencyCopyActor.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/copy/DependencyCopyActor.scala
@@ -70,7 +70,7 @@ class DependencyCopyActor() extends PersistentActor with ActorLogging {
   override def receiveCommand: Receive = {
 
     case ContinueTask(ExecuteTask(_, task: DependencyCopyTask, _)) =>
-      checkForCreatedResources = scheduler.schedule(0 seconds, 15 seconds, self, CheckCompletion())
+      checkForCreatedResources = scheduler.schedule(0 seconds, 10 seconds, self, CheckCompletion())
 
     case event @ ExecuteTask(_, _: DependencyCopyTask, _) =>
       persist(event) { e =>
@@ -183,7 +183,7 @@ class DependencyCopyActor() extends PersistentActor with ActorLogging {
   }
 
   private def startResourceCopying(): Unit = {
-    checkForCreatedResources = scheduler.schedule(15 seconds, 15 seconds, self, CheckCompletion())
+    checkForCreatedResources = scheduler.schedule(10 seconds, 10 seconds, self, CheckCompletion())
     task.requiredSecurityGroupNames.foreach { it =>
       self ! RequiresSource(resourceTracker.asSourceSecurityGroupReference(it), None)
     }

--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/polling/PollingDirector.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/polling/PollingDirector.scala
@@ -17,7 +17,7 @@ class PollingDirector extends Actor {
   var pollInit: Option[PollInit] = None
 
   private implicit val dispatcher = context.dispatcher
-  val tick = context.system.scheduler.schedule(0 seconds, 15 seconds, self, Poll())
+  val tick = context.system.scheduler.schedule(0 seconds, 10 seconds, self, Poll())
 
   override def postStop() = {
     tick.cancel()

--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/service/CloudDriverActor.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/service/CloudDriverActor.scala
@@ -130,18 +130,18 @@ object ConstructCloudDriverOperations {
       healthCheck.interval, healthCheck.timeout, healthCheck.unhealthyThreshold, healthCheck.healthyThreshold, listeners)
   }
 
-  def constructCloneServerGroupOperation(awsReference: AwsReference[ServerGroupIdentity],
+  def constructCloneServerGroupOperation(source: AwsReference[ServerGroupIdentity],
                                          cloneServerGroup: CloneServerGroup): CloneServerGroupOperation = {
-    val awsLocation = awsReference.location
+    val target = cloneServerGroup.target
     val autoScalingGroup = cloneServerGroup.autoScalingGroup
     val launchConfiguration = cloneServerGroup.launchConfiguration
 
     val availabilityZones: Map[String, Set[String]] = Map(
-      awsReference.location.region -> autoScalingGroup.availabilityZones
+      target.location.region -> autoScalingGroup.availabilityZones
     )
 
     val capacity = Capacity(autoScalingGroup.minSize, autoScalingGroup.maxSize, autoScalingGroup.desiredCapacity)
-    val names = Names.parseName(awsReference.identity.autoScalingGroupName)
+    val names = Names.parseName(source.identity.autoScalingGroupName)
 
     val application = cloneServerGroup.application.getOrElse(names.getApp)
     val stack = cloneServerGroup.stack.getOrElse(names.getStack)
@@ -149,13 +149,13 @@ object ConstructCloudDriverOperations {
 
     CloneServerGroupOperation(application, stack, detail,
       autoScalingGroup.subnetType, autoScalingGroup.vpcName, availabilityZones,
-      awsLocation.account, launchConfiguration.securityGroups, autoScalingGroup.loadBalancerNames, capacity,
+      target.location.account, launchConfiguration.securityGroups, autoScalingGroup.loadBalancerNames, capacity,
       launchConfiguration.iamInstanceProfile, launchConfiguration.keyName, launchConfiguration.imageId,
       launchConfiguration.instanceType, launchConfiguration.associatePublicIpAddress, launchConfiguration.ramdiskId,
       autoScalingGroup.terminationPolicies, autoScalingGroup.suspendedProcesses,
       launchConfiguration.spotPrice, autoScalingGroup.healthCheckType, autoScalingGroup.healthCheckGracePeriod,
       autoScalingGroup.defaultCooldown, launchConfiguration.isInstanceMonitoringEnabled,
-      launchConfiguration.ebsOptimized, cloneServerGroup.startDisabled, Source.from(awsReference))
+      launchConfiguration.ebsOptimized, cloneServerGroup.startDisabled, Source.from(source))
   }
 
   def constructAttachClassicLinkVpcOperation(awsReference: AwsReference[InstanceIdentity],

--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/model/AwsApi.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/model/AwsApi.scala
@@ -62,7 +62,7 @@ object AwsApi {
     @JsonIgnore override def akkaIdentifier = s"$account.$region"
   }
 
-  case class VpcLocation(@JsonUnwrapped location: AwsLocation, vpcName: Option[String])
+  case class VpcLocation(@JsonUnwrapped location: AwsLocation, vpcName: Option[String], keyName: Option[String] = Option.empty)
 
   trait AwsIdentity extends AkkaClustered
 

--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/model/AwsResourceProtocol.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/model/AwsResourceProtocol.scala
@@ -50,6 +50,7 @@ case class LoadBalancerDetails(awsReference: AwsReference[LoadBalancerIdentity],
 case class GetServerGroup() extends ServerGroupEvent
 case class CloneServerGroup(autoScalingGroup: AutoScalingGroupState, launchConfiguration: LaunchConfigurationState,
                             startDisabled: Boolean = false, application: Option[String] = None,
+                            target: VpcLocation,
                             stack: Option[String] = None, detail: Option[String] = None) extends ServerGroupEvent
 case class ServerGroupLatestState(autoScalingGroup: AutoScalingGroupState,
                                   launchConfiguration: LaunchConfigurationState) extends ServerGroupEvent

--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/model/ResourceTracker.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/model/ResourceTracker.scala
@@ -49,7 +49,7 @@ case class ResourceTracker(source: VpcLocation, target: VpcLocation, vpcIds: Vpc
       case sourceIdentity: SecurityGroupIdentity =>
         sourceIdentity.dropLegacySuffix.copy(vpcId = vpcIds.target).asInstanceOf[T]
     }
-    TargetResource(AwsReference(source.location, targetIdentity))
+    TargetResource(AwsReference(target.location, targetIdentity))
   }
 
   def getSourceByTarget[T <: AwsIdentity](targetResource: TargetResource[T]): SourceResource[T] = {

--- a/tide-web/src/main/scala/com/netflix/spinnaker/tide/WebModel.scala
+++ b/tide-web/src/main/scala/com/netflix/spinnaker/tide/WebModel.scala
@@ -25,9 +25,9 @@ import scala.beans.BeanProperty
 
 object WebModel {
 
-  case class VpcDefinition(@BeanProperty account: String, @BeanProperty region: String, @BeanProperty vpcName: String) {
+  case class VpcDefinition(@BeanProperty account: String, @BeanProperty region: String, @BeanProperty vpcName: String, @BeanProperty keyName: String) {
     def toVpcLocation = {
-      VpcLocation(AwsLocation(account, region), Option(vpcName))
+      VpcLocation(AwsLocation(account, region), Option(vpcName), Option(keyName))
     }
   }
   case class DependencyCopyDefinition(@BeanProperty source: VpcDefinition,


### PR DESCRIPTION
Adding `keyName` to the target, then applying that if provided as an override