### PR TITLE
bump timeout on task retrieval

### DIFF
--- a/tide-web/src/main/scala/com/netflix/spinnaker/tide/controllers/TaskController.scala
+++ b/tide-web/src/main/scala/com/netflix/spinnaker/tide/controllers/TaskController.scala
@@ -19,7 +19,7 @@ import scala.concurrent.Await
 @RestController
 class TaskController @Autowired()(private val clusterSharding: ClusterSharding) {
 
-  implicit val timeout = Timeout(5 seconds)
+  implicit val timeout = Timeout(15 seconds)
 
   @RequestMapping(value = Array("/{id}"), method = Array(GET))
   def getTask(@PathVariable("id") id: String): TaskStatus = {


### PR DESCRIPTION
consistently seeing a stream of future timeout messages, throwing this at the wall to see if it makes a difference