### PR TITLE
only poll classic linking on enabled accounts

### DIFF
--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/ContinuousInitActor.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/ContinuousInitActor.scala
@@ -10,12 +10,14 @@ import com.netflix.spinnaker.tide.actor.polling.PollingDirector
 import com.netflix.spinnaker.tide.actor.polling.PollingDirector.PollInit
 import com.netflix.spinnaker.tide.actor.task.TaskDirector
 import com.netflix.spinnaker.tide.actor.task.TaskDirector.GetRunningTasks
+import com.netflix.spinnaker.tide.config.ClassicLinkSettings
+
 import scala.concurrent.duration.DurationInt
 import scala.collection.JavaConverters._
 
 class ContinuousInitActor(clusterSharding: ClusterSharding,
                           accountCredentialsRepository: AccountCredentialsRepository,
-                          classicLinkSecurityGroupNames: Seq[String]) extends Actor with ActorLogging {
+                          classicLinkSettings: ClassicLinkSettings) extends Actor with ActorLogging {
 
   private implicit val dispatcher = context.dispatcher
   val tick = context.system.scheduler.schedule(0 seconds, 5 seconds, self, Tick())
@@ -41,7 +43,7 @@ class ContinuousInitActor(clusterSharding: ClusterSharding,
         credential.getAccountId -> credential.getName
       }.toMap
       clusterSharding.shardRegion(PollingDirector.typeName) ! PollInit(accountNamesToRegionNames,
-        classicLinkSecurityGroupNames, AccountMetaData(accountIdsToNames))
+        classicLinkSettings, AccountMetaData(accountIdsToNames))
       clusterSharding.shardRegion(TaskDirector.typeName) ! GetRunningTasks()
     case _ =>
   }

--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/config/AkkaClusterConfiguration.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/config/AkkaClusterConfiguration.scala
@@ -26,12 +26,10 @@ import com.netflix.spinnaker.tide.actor.aws._
 import com.netflix.spinnaker.tide.actor.classiclink.{AttachClassicLinkActor, ClassicLinkInstancesActor}
 import com.netflix.spinnaker.tide.actor.comparison.AttributeDiffActor
 import com.netflix.spinnaker.tide.actor.copy.{ServerGroupDeepCopyActor, PipelineDeepCopyActor, DependencyCopyActor}
-import com.netflix.spinnaker.tide.actor.polling.PollingDirector.PollInit
 import com.netflix.spinnaker.tide.actor.polling._
 import com.netflix.spinnaker.tide.actor.service.{Front50Actor, CloudDriverActor}
 import com.netflix.spinnaker.tide.actor.service.CloudDriverActor.CloudDriverInit
 import com.netflix.spinnaker.tide.actor.service.Front50Actor.Front50Init
-import com.netflix.spinnaker.tide.actor.task.TaskDirector.GetRunningTasks
 import com.netflix.spinnaker.tide.actor.task.{TaskActor, TaskDirector}
 import com.netflix.spinnaker.tide.actor.{ContinuousInitActor, ClusterTestActor}
 import org.springframework.beans.factory.annotation.{Value, Autowired}
@@ -94,8 +92,7 @@ class AkkaClusterConfiguration {
   def initActors() = {
     clusterSharding.shardRegion(CloudDriverActor.typeName) ! CloudDriverInit(cloudDriverApiUrl)
     clusterSharding.shardRegion(Front50Actor.typeName) ! Front50Init(front50ApiUrl)
-    val classicLinkSecurityGroupNames: Seq[String] = classicLinkSettings.getSecurityGroups.asScala
-    val props = Props(classOf[ContinuousInitActor], clusterSharding, accountCredentialsRepository, classicLinkSecurityGroupNames)
+    val props = Props(classOf[ContinuousInitActor], clusterSharding, accountCredentialsRepository, classicLinkSettings)
     system.actorOf(props, "ContinuousInit")
   }
 
@@ -114,6 +111,7 @@ class AkkaClusterConfiguration {
 
 class ClassicLinkSettings {
   @BeanProperty var securityGroups: java.util.List[String] = _
+  @BeanProperty var accounts: java.util.List[String] = _
 }
 
 object OkHttpClientConfigurationHolder {


### PR DESCRIPTION
Some accounts only exist in VPC, so trying to run all the classic link actors against those accounts just fills the logs with errors from AWS.

If we need to get more granular with this configuration, we can. For now, this should help.