### PR TITLE
handle alt names for classiclink sg, allow launch on clone ops

### DIFF
--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/copy/DependencyCopyActor.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/copy/DependencyCopyActor.scala
@@ -317,7 +317,7 @@ class DependencyCopyActor() extends PersistentActor with ActorLogging {
         case Some(ingressAccountName) =>
           val dependencyCopyTask = DependencyCopyTask(
             VpcLocation(task.source.location.copy(account = ingressAccountName), task.source.vpcName),
-            VpcLocation(task.target.location.copy(account = ingressAccountName), task.target.vpcName),
+            VpcLocation(task.target.location.copy(account = targetAccount), task.target.vpcName),
             Set(ingressGroupName),
             Set(), None, allowIngressFromClassic = task.allowIngressFromClassic, dryRun = task.dryRun,
             skipAllIngress = true)

--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/model/CloudDriverService.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/model/CloudDriverService.scala
@@ -172,6 +172,10 @@ object CloudDriverService {
     val operationTypeName = "copyLastAsgDescription"
   }
 
+  case class AllowLaunchOperation(account: String, amiName: String, region: String, credentials: String = "test") extends CloudDriverOperation {
+    val operationTypeName = "allowLaunchDescription"
+  }
+
   case class Capacity(min: Int, max: Int, desired: Int)
 
   case class Source(account: String, region: String, asgName: String)

--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/transform/SecurityGroupConventions.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/transform/SecurityGroupConventions.scala
@@ -4,6 +4,10 @@ import com.netflix.spinnaker.tide.model.AwsApi.{AccountIdentifier, UserIdGroupPa
 
 case class SecurityGroupConventions(appName: String, accountName: String, vpcName: Option[String]) {
 
+  private val accountsToClassicLink: Map[String, String] = Map(
+    "persistence_test" -> "nf-classiclink-rds"
+  )
+
   private def constructClassicLinkIpPermission: IpPermission = {
     IpPermission (
       fromPort = Some(80),
@@ -12,7 +16,7 @@ case class SecurityGroupConventions(appName: String, accountName: String, vpcNam
       ipRanges = Set(),
       userIdGroupPairs = Set(UserIdGroupPairs(
         groupId = None,
-        groupName = Some("nf-classiclink"),
+        groupName = Some(accountsToClassicLink.getOrElse(accountName, "nf-classiclink")),
         AccountIdentifier("", Some(accountName)),
         vpcName
       ))


### PR DESCRIPTION
Handling two issues:

1. Some accounts use different security groups for classiclink. We should handle that via config, but, frankly, this is easier and deploying this app is just as fast via a code change as via a config change.
2. If we target a different account when migrating, we should allow launch first.