### PR TITLE
skip generating app security group if not needed

### DIFF
--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/copy/DependencyCopyActor.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/copy/DependencyCopyActor.scala
@@ -284,7 +284,7 @@ class DependencyCopyActor() extends PersistentActor with ActorLogging {
     task.appName match {
       case Some(appName) =>
         newIngress ++ SecurityGroupConventions(appName, task.target.location.account, task.target.vpcName).
-          appendBoilerplateIngress(groupName, task.allowIngressFromClassic)
+          appendBoilerplateIngress(groupName, task.allowIngressFromClassic, task.sourceLoadBalancerNames.nonEmpty)
       case _ =>
         newIngress
     }


### PR DESCRIPTION
The `app-elb` security group is getting created due to the ingress permission - let's not create it if there are no ELBs present in the ASG being migrated