### PR TITLE
do not overprovision security groups when switching accounts

### DIFF
--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/copy/DependencyCopyActor.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/actor/copy/DependencyCopyActor.scala
@@ -317,7 +317,7 @@ class DependencyCopyActor() extends PersistentActor with ActorLogging {
         case Some(ingressAccountName) =>
           val dependencyCopyTask = DependencyCopyTask(
             VpcLocation(task.source.location.copy(account = ingressAccountName), task.source.vpcName),
-            VpcLocation(task.target.location.copy(account = targetAccount), task.target.vpcName),
+            VpcLocation(task.target.location.copy(account = ingressAccountName), task.target.vpcName),
             Set(ingressGroupName),
             Set(), None, allowIngressFromClassic = task.allowIngressFromClassic, dryRun = task.dryRun,
             skipAllIngress = true)


### PR DESCRIPTION
If a user is switching accounts when migrating an app, there's no need to migrate all the security groups that have ingress permissions into the new account (I made this dumb change recently).