### PR TITLE
change skipped resource signature for orca compat

### DIFF
--- a/tide-core/src/main/scala/com/netflix/spinnaker/tide/model/AwsApi.scala
+++ b/tide-core/src/main/scala/com/netflix/spinnaker/tide/model/AwsApi.scala
@@ -75,7 +75,7 @@ object AwsApi {
   case class CreateAwsResource(awsReference: AwsReference[_ <: AwsIdentity],
                                referencedBy: Option[AwsReference[_]], objectToCreate: Option[Any]= None) extends MutationDetails
 
-  case class SkippedIngressRule(group: UserIdGroupPairs, source: String) extends MutationDetails
+  case class SkippedIngressRule(awsReference: UserIdGroupPairs, source: String) extends MutationDetails
 
   case class SecurityGroup(groupId: String,
                            @JsonUnwrapped @JsonProperty("name") identity: SecurityGroupIdentity,


### PR DESCRIPTION
Either I change it here or I change it in Orca - otherwise, Orca will ignore the property and we won't get any details back. It's easier to change here, frankly.